### PR TITLE
POSTYC-54 Fixed double base64 encoding of document

### DIFF
--- a/src/YellowCube/WAB/Doc.php
+++ b/src/YellowCube/WAB/Doc.php
@@ -81,7 +81,7 @@ class Doc
         return new self(
             $DocType,
             $DocMimeType,
-            base64_encode(file_get_contents($FilePath))
+            file_get_contents($FilePath)
         );
     }
 


### PR DESCRIPTION
The SoapClient::SoapClient does automatically encode base64 if it is defined in wsdl/xsd file.
See http://php.net/manual/en/soapclient.soapclient.php#98658

As a result, we don't need to manually call base64_encode() in Doc::fromFile().